### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action/javascript.php
+++ b/action/javascript.php
@@ -10,7 +10,7 @@ require_once DOKU_PLUGIN.'action.php';
 
 class action_plugin_rigrr_javascript extends DokuWiki_Action_Plugin {
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
 		$controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_hook_header');
 	}
 

--- a/syntax.php
+++ b/syntax.php
@@ -31,11 +31,11 @@ class syntax_plugin_rigrr extends DokuWiki_Syntax_Plugin {
     function connectTo($mode) {  $this->Lexer->addEntryPattern('<rigrr.*?>(?=.*?</rigrr>)',$mode,'plugin_rigrr'); }
     function postConnect() { $this->Lexer->addExitPattern('</rigrr>','plugin_rigrr'); }
      
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return array($match, $state, $pos);
     }
      
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
     // $data is what the function handle return'ed.
         if($mode == 'xhtml'){
             list($match,$state,$pos) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
